### PR TITLE
Remove level information from wind gust

### DIFF
--- a/src/anemoi_plugins_meteoswiss/transform/sources/realch1_wind_gust.py
+++ b/src/anemoi_plugins_meteoswiss/transform/sources/realch1_wind_gust.py
@@ -118,7 +118,7 @@ def _get_data_from_fdb(request: dict[str, Any], dates: list[datetime]):
     for request in requests:
         fl += ekd.from_source("fdb", request, read_all=True)
 
-    return fl
+    return ekd.FieldList.from_fields([f.clone(level=None, levelist=None) for f in fl])
 
 
 def _aggregate(fl: ekd.FieldList) -> ekd.FieldList:


### PR DESCRIPTION
This pull request updates the return value of the `_get_data_from_fdb` function to ensure that all fields in the returned `FieldList` have their `level` and `levelist` attributes set to `None`. This will ensure the variable name in the final anemoi dataset will not have a `_{levelist}` suffix (for other sources this is achieved via "flavours").