### PR TITLE
Add cscs-ci

### DIFF
--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -11,7 +11,6 @@ include:
 stages:
   - test
 
-
 .baremetal-runner-balfrin:
   extends: [.baremetal-runner-santis-gh200]
   variables:

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -1,10 +1,11 @@
-# ci/tests.yaml — CSCS HPC pipeline "tests" (hello-world smoke test). On-demand only.
+# ci/tests.yaml — CSCS HPC pipeline "tests" (smoke test). On-demand only.
 # Trigger:  PR comment `cscs-ci run tests`  or the trigger API.
 #
-# One job on the CSCS balfrin runner: check out the repo, confirm the CI
-# context looks right, and prove uv/python are usable. No devml/workspace or
-# inference machinery yet — this just verifies the pipeline itself works;
-# real build/test steps can be layered on once this is green.
+# Single job that allocates a compute node on balfrin and syncs the uv
+# environment. This proves the CSCS-CI plumbing (auth, runner, SLURM
+# allocation) and the uv environment setup work end-to-end. No FDB/uenv
+# dataset-create step yet — that can be layered on in a follow-up once this
+# is green.
 include:
   - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
 
@@ -19,29 +20,56 @@ stages:
     ARCH: 'x86_64'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
-    SLURM_TIMELIMIT: '00:10:00'
+    # uv sync builds the venv from scratch (eccodes, earthkit, meteodata-lab,
+    # ...); give it more room than a bare hello-world needs.
+    SLURM_TIMELIMIT: '00:20:00'
 
-hello:
-  extends: [.baremetal-runner-balfrin]
-  stage: test
+# ── reusable script fragments (hidden jobs) ──────────────────────────────────
+
+# Strict mode + a banner() helper for section headers. Referenced first so
+# both are in scope for every fragment that follows.
+.sh_preamble:
   script:
     - |
       set -euo pipefail
       banner() { printf '\n\033[1;36m==== %s ====\033[0m\n' "$*"; }
 
+# Print CI context up front so the log is self-explanatory.
+.log_ci_context:
+  script:
+    - |
       banner "CI context"
       echo "host=$(hostname -f 2>/dev/null || hostname)  user=$(whoami)"
       echo "project=${CI_PROJECT_PATH:-?}  ref=${CI_COMMIT_REF_NAME:-?}  sha=${CI_COMMIT_SHA:-?}"
-      echo "pipeline=${CI_PIPELINE_ID:-?}  job=${CI_JOB_ID:-?}"
-      echo "PWD=$PWD"
 
-      banner "Checkout"
-      ls -la
+# The runner already checked the repo out into $PWD. HOME is repointed there
+# since the compute node has no mounted home directory.
+.install_uv:
+  script:
+    - |
+      banner "Install uv"
+      export UV_CACHE_DIR="$SCRATCH/.cache/uv"  # wheel cache, persistent across pipelines
+      export HOME="$PWD/home"
+      export PATH="$PWD/.local/bin:$PATH"
+      # uv: bare metal assumes a user-managed env, so we install it ourselves
+      export UV_INSTALL_DIR="$PWD/.local/bin"
+      UV_VERSION='0.11.32'
+      curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | env INSTALLER_NO_MODIFY_PATH=1 sh
+      uv --version
 
-      banner "Tool availability"
-      for t in git curl uv python3; do
-        if command -v "$t" >/dev/null 2>&1; then echo "  $t: $("$t" --version 2>&1 | head -1)"; else echo "  $t: MISSING"; fi
-      done
+.uv_sync:
+  script:
+    - |
+      banner "uv sync"
+      uv sync --dev
 
-      banner "Hello, world"
-      echo "anemoi-plugins-meteoswiss CI pipeline is alive."
+# ── pipeline ─────────────────────────────────────────────────────────────────
+
+tests:
+  extends: [.baremetal-runner-balfrin]
+  stage: test
+  script:
+    - !reference [.sh_preamble, script]
+    - !reference [.log_ci_context, script]
+    - !reference [.install_uv, script]
+    - !reference [.uv_sync, script]

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -1,0 +1,47 @@
+# ci/tests.yaml — CSCS HPC pipeline "tests" (hello-world smoke test). On-demand only.
+# Trigger:  PR comment `cscs-ci run tests`  or the trigger API.
+#
+# One job on the CSCS balfrin runner: check out the repo, confirm the CI
+# context looks right, and prove uv/python are usable. No devml/workspace or
+# inference machinery yet — this just verifies the pipeline itself works;
+# real build/test steps can be layered on once this is green.
+include:
+  - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
+
+stages:
+  - test
+
+.baremetal-runner-balfrin:
+  extends: [.baremetal-runner-santis-gh200]
+  variables:
+    F7T_URL: 'https://api.cscs.ch/mch/firecrest/v2'
+    FIRECREST_SYSTEM: 'balfrin'
+    ARCH: 'x86_64'
+    SLURM_JOB_NUM_NODES: 1
+    SLURM_NTASKS: 1
+    SLURM_TIMELIMIT: '00:10:00'
+
+hello:
+  extends: [.baremetal-runner-balfrin]
+  stage: test
+  script:
+    - |
+      set -euo pipefail
+      banner() { printf '\n\033[1;36m==== %s ====\033[0m\n' "$*"; }
+
+      banner "CI context"
+      echo "host=$(hostname -f 2>/dev/null || hostname)  user=$(whoami)"
+      echo "project=${CI_PROJECT_PATH:-?}  ref=${CI_COMMIT_REF_NAME:-?}  sha=${CI_COMMIT_SHA:-?}"
+      echo "pipeline=${CI_PIPELINE_ID:-?}  job=${CI_JOB_ID:-?}"
+      echo "PWD=$PWD"
+
+      banner "Checkout"
+      ls -la
+
+      banner "Tool availability"
+      for t in git curl uv python3; do
+        if command -v "$t" >/dev/null 2>&1; then echo "  $t: $("$t" --version 2>&1 | head -1)"; else echo "  $t: MISSING"; fi
+      done
+
+      banner "Hello, world"
+      echo "anemoi-plugins-meteoswiss CI pipeline is alive."

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -11,6 +11,7 @@ include:
 stages:
   - test
 
+
 .baremetal-runner-balfrin:
   extends: [.baremetal-runner-santis-gh200]
   variables:


### PR DESCRIPTION
Adds ci/tests.yaml, a GitLab CI pipeline that runs on CSCS's balfrin bare-metal runner.
For now the pipeline is minimal — a single tests job that:
- Allocates one node on balfrin
- Installs uv (bare-metal runner has no user-managed environment)
- Runs uv sync --dev to build the project's venv