### PR TITLE
bugfix: skip no-commit-to-branch pre-commit in github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,4 +50,4 @@ jobs:
         uses: actions/setup-python@v5
 
       - name: Run pre-commit hooks
-        run: uvx pre-commit run --all-files
+        run: SKIP=no-commit-to-branch uvx pre-commit run --all-files


### PR DESCRIPTION
This hook is intended to prevent local commits directly to protected branches. Excluding it from the CI prevents false failures.